### PR TITLE
Add OAuth connect sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# sample app data store
+storage.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# wise-platform-samples
-Code samples to get started with common Wise API use cases
+# Wise Platform samples
+
+Code samples to get started with common Wise API use cases.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Wise Platform samples
 
 Code samples to get started with common Wise API use cases.
+
+Each sample includes server and client side code (powered by [Next.js](https://nextjs.org/)).
+All calls to Wise API are done on the server side.
+
+Start by picking a sample and look into `pages/index.tsx` (landing page).

--- a/common/const/index.ts
+++ b/common/const/index.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_REDIRECT_URI = 'http://localhost:3000/wise-redirect';

--- a/common/db/index.ts
+++ b/common/db/index.ts
@@ -1,0 +1,28 @@
+import store from './mockDataStore';
+import type { Config } from '../types/Config';
+import type { Tokens } from '../types/Tokens';
+
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+
+export const getSelectedWiseProfileId = () => store.get('selectedProfileId') as string;
+
+export const getWiseEnvironmentConfig = () => store.get('config') as Config;
+
+export const getWiseTokens = () => {
+  const selectedProfileId = getSelectedWiseProfileId();
+  return store.get(selectedProfileId) as Tokens;
+};
+
+export const getWiseAccessToken = () => {
+  return getWiseTokens().accessToken;
+};
+
+export const getWiseRefreshToken = () => {
+  return getWiseTokens().refreshToken;
+};
+
+export const isWiseTokenAboutToExpire = ()=> {
+  const tokens = getWiseTokens();
+  // Token already expired or will expire within 1 hour
+  return Date.now() > parseInt(tokens.accessTokenExpiresAt, 10) - ONE_HOUR_IN_MS;
+};

--- a/common/db/index.ts
+++ b/common/db/index.ts
@@ -1,8 +1,12 @@
-import store from './mockDataStore';
+import JSONdb from '../lib/Simple-JSONdb';
+
 import type { Config } from '../types/Config';
 import type { Tokens } from '../types/Tokens';
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+
+// Instead of proper database we have a simple JSON file
+export const store = new JSONdb('../storage.json');
 
 export const getSelectedWiseProfileId = () => store.get('selectedProfileId') as string;
 
@@ -10,6 +14,9 @@ export const getWiseEnvironmentConfig = () => store.get('config') as Config;
 
 export const getWiseTokens = () => {
   const selectedProfileId = getSelectedWiseProfileId();
+  if (!selectedProfileId) {
+    throw Error('No selectedProfileId');
+  }
   return store.get(selectedProfileId) as Tokens;
 };
 

--- a/common/db/mockDataStore.ts
+++ b/common/db/mockDataStore.ts
@@ -1,6 +1,0 @@
-// TODO: add comment
-const JSONdb = require('../lib/Simple-JSONdb');
-
-const dataStore = new JSONdb('../storage.json');
-
-export default dataStore;

--- a/common/db/mockDataStore.ts
+++ b/common/db/mockDataStore.ts
@@ -1,0 +1,6 @@
+// TODO: add comment
+const JSONdb = require('../lib/Simple-JSONdb');
+
+const dataStore = new JSONdb('../storage.json');
+
+export default dataStore;

--- a/common/lib/Simple-JSONdb.js
+++ b/common/lib/Simple-JSONdb.js
@@ -1,0 +1,189 @@
+/**
+ * In order to keep each example app very light we're cloning source of
+ * Simple-JSONdb here. This way we don't need to install it for every new sample app we create.
+ * 
+ * https://github.com/nmaggioni/Simple-JSONdb/
+ */
+const fs = require("fs");
+
+/**
+ * Default configuration values.
+ * @type {{asyncWrite: boolean, syncOnWrite: boolean, jsonSpaces: number}}
+ */
+const defaultOptions = {
+  asyncWrite: false,
+  syncOnWrite: true,
+  jsonSpaces: 4,
+  stringify: JSON.stringify,
+  parse: JSON.parse
+};
+
+/**
+ * Validates the contents of a JSON file.
+ * @param {string} fileContent
+ * @returns {boolean} `true` if content is ok, throws error if not.
+ */
+let validateJSON = function(fileContent) {
+  try {
+    this.options.parse(fileContent);
+  } catch (e) {
+    console.error('Given filePath is not empty and its content is not valid JSON.');
+    throw e;
+  }
+  return true;
+};
+
+/**
+ * Main constructor, manages existing storage file and parses options against default ones.
+ * @param {string} filePath The path of the file to use as storage.
+ * @param {object} [options] Configuration options.
+ * @param {boolean} [options.asyncWrite] Enables the storage to be asynchronously written to disk. Disabled by default (synchronous behaviour).
+ * @param {boolean} [options.syncOnWrite] Makes the storage be written to disk after every modification. Enabled by default.
+ * @param {boolean} [options.syncOnWrite] Makes the storage be written to disk after every modification. Enabled by default.
+ * @param {number} [options.jsonSpaces] How many spaces to use for indentation in the output json files. Default = 4
+ * @constructor
+ */
+function JSONdb(filePath, options) {
+  // Mandatory arguments check
+  if (!filePath || !filePath.length) {
+    throw new Error('Missing file path argument.');
+  } else {
+    this.filePath = filePath;
+  }
+
+  // Options parsing
+  if (options) {
+    for (let key in defaultOptions) {
+      if (!options.hasOwnProperty(key)) options[key] = defaultOptions[key];
+    }
+    this.options = options;
+  } else {
+    this.options = defaultOptions;
+  }
+
+
+  // Storage initialization
+  this.storage = {};
+
+  // File existence check
+  let stats;
+  try {
+    stats = fs.statSync(filePath);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      /* File doesn't exist */
+      return;
+    } else if (err.code === 'EACCES') {
+      throw new Error(`Cannot access path "${filePath}".`);
+    } else {
+      // Other error
+      throw new Error(`Error while checking for existence of path "${filePath}": ${err}`);
+    }
+  }
+  /* File exists */
+  try {
+    fs.accessSync(filePath, fs.constants.R_OK | fs.constants.W_OK);
+  } catch (err) {
+    throw new Error(`Cannot read & write on path "${filePath}". Check permissions!`);
+  }
+  if (stats.size > 0) {
+    let data;
+    try {
+      data = fs.readFileSync(filePath);
+    } catch (err) {
+      throw err;  // TODO: Do something meaningful
+    }
+    if (validateJSON.bind(this)(data)) this.storage = this.options.parse(data);
+  }
+}
+
+/**
+ * Creates or modifies a key in the database.
+ * @param {string} key The key to create or alter.
+ * @param {object} value Whatever to store in the key. You name it, just keep it JSON-friendly.
+ */
+JSONdb.prototype.set = function(key, value) {
+  this.storage[key] = value;
+  if (this.options && this.options.syncOnWrite) this.sync();
+};
+
+/**
+ * Extracts the value of a key from the database.
+ * @param {string} key The key to search for.
+ * @returns {object|undefined} The value of the key or `undefined` if it doesn't exist.
+ */
+JSONdb.prototype.get = function(key) {
+  return this.storage.hasOwnProperty(key) ? this.storage[key] : undefined;
+};
+
+/**
+ * Checks if a key is contained in the database.
+ * @param {string} key The key to search for.
+ * @returns {boolean} `True` if it exists, `false` if not.
+ */
+JSONdb.prototype.has = function(key) {
+  return this.storage.hasOwnProperty(key);
+};
+
+/**
+ * Deletes a key from the database.
+ * @param {string} key The key to delete.
+ * @returns {boolean|undefined} `true` if the deletion succeeded, `false` if there was an error, or `undefined` if the key wasn't found.
+ */
+JSONdb.prototype.delete = function(key) {
+  let retVal = this.storage.hasOwnProperty(key) ? delete this.storage[key] : undefined;
+  if (this.options && this.options.syncOnWrite) this.sync();
+  return retVal;
+};
+
+/**
+ * Deletes all keys from the database.
+ * @returns {object} The JSONdb instance itself.
+ */
+JSONdb.prototype.deleteAll = function() {
+  for (var key in this.storage) {
+    //noinspection JSUnfilteredForInLoop
+    this.delete(key);
+  }
+  return this;
+};
+
+/**
+ * Writes the local storage object to disk.
+ */
+JSONdb.prototype.sync = function() {
+  if (this.options && this.options.asyncWrite) {
+    fs.writeFile(this.filePath, this.options.stringify(this.storage, null, this.options.jsonSpaces), (err) => {
+      if (err) throw err;
+    });
+  } else {
+    try {
+      fs.writeFileSync(this.filePath, this.options.stringify(this.storage, null, this.options.jsonSpaces));
+    } catch (err) {
+      if (err.code === 'EACCES') {
+        throw new Error(`Cannot access path "${this.filePath}".`);
+      } else {
+        throw new Error(`Error while writing to path "${this.filePath}": ${err}`);
+      }
+    }
+  }
+};
+
+/**
+ * If no parameter is given, returns **a copy** of the local storage. If an object is given, it is used to replace the local storage.
+ * @param {object} storage A JSON object to overwrite the local storage with.
+ * @returns {object} Clone of the internal JSON storage. `Error` if a parameter was given and it was not a valid JSON object.
+ */
+JSONdb.prototype.JSON = function(storage) {
+  if (storage) {
+    try {
+      JSON.parse(this.options.stringify(storage));
+      this.storage = storage;
+    } catch (err) {
+      throw new Error('Given parameter is not a valid JSON object.');
+    }
+  }
+  return JSON.parse(this.options.stringify(this.storage));
+};
+
+module.exports = JSONdb;

--- a/common/server/exchangeAuthCodeForToken.ts
+++ b/common/server/exchangeAuthCodeForToken.ts
@@ -2,8 +2,6 @@ import { getWiseEnvironmentConfig } from '../db';
 import store from '../db/mockDataStore';
 import { toUrlencoded } from '../utils/toUrlencoded';
 
-const MINUTE_IN_MS = 60 * 1000;
-
 // Obtain Wise access token and refresh token.
 // https://docs.wise.com/api-docs/api-reference/user-tokens#authzcode
 export const exchangeAuthCodeForToken = async (
@@ -43,7 +41,7 @@ export const exchangeAuthCodeForToken = async (
   store.set(profileId, {
     accessToken: result.access_token,
     refreshToken: result.refresh_token,
-    // Turns expires_in (seconds) into timestamp so we can use it later
-    accessTokenExpiresAt: Date.now() + result.expires_in * MINUTE_IN_MS,
+    // Turns expires_in (seconds) into JS timestamp (milliseconds) so we can use it later
+    accessTokenExpiresAt: Date.now() + result.expires_in * 1000,
   });
 };

--- a/common/server/exchangeAuthCodeForToken.ts
+++ b/common/server/exchangeAuthCodeForToken.ts
@@ -1,0 +1,49 @@
+import { getWiseEnvironmentConfig } from '../db';
+import store from '../db/mockDataStore';
+import { toUrlencoded } from '../utils/toUrlencoded';
+
+const MINUTE_IN_MS = 60 * 1000;
+
+// Obtain Wise access token and refresh token.
+// https://docs.wise.com/api-docs/api-reference/user-tokens#authzcode
+export const exchangeAuthCodeForToken = async (
+  authCode: string,
+  profileId: string
+) => {
+  const config = getWiseEnvironmentConfig();
+  const headers = new Headers();
+  headers.set(
+    'Content-Type',
+    'application/x-www-form-urlencoded;charset=UTF-8'
+  );
+  headers.set(
+    'Authorization',
+    `Basic ${Buffer.from(`${config.clientId}:${config.clientSecret}`).toString(
+      'base64'
+    )}`
+  );
+
+  const body = toUrlencoded({
+    grant_type: 'authorization_code',
+    client_id: config.clientId,
+    code: authCode.toString(),
+    redirect_uri: config.redirectUri,
+  });
+
+  const response = await fetch(`${config.host}/oauth/token`, {
+    method: 'POST',
+    headers,
+    body,
+  });
+  const result = await response.json();
+  // Stores Wise profileId and tokens in our demo database (storage.json).
+  // In a production environment, you would associate these tokens with a logged-in user
+  // in your system.
+  store.set('selectedProfileId', profileId);
+  store.set(profileId, {
+    accessToken: result.access_token,
+    refreshToken: result.refresh_token,
+    // Turns expires_in (seconds) into timestamp so we can use it later
+    accessTokenExpiresAt: Date.now() + result.expires_in * MINUTE_IN_MS,
+  });
+};

--- a/common/server/exchangeAuthCodeForToken.ts
+++ b/common/server/exchangeAuthCodeForToken.ts
@@ -1,5 +1,5 @@
 import { getWiseEnvironmentConfig } from '../db';
-import store from '../db/mockDataStore';
+import { store } from '../db';
 import { toUrlencoded } from '../utils/toUrlencoded';
 
 // Obtain Wise access token and refresh token.

--- a/common/server/fetchProfileDetails.ts
+++ b/common/server/fetchProfileDetails.ts
@@ -1,0 +1,12 @@
+import { getSelectedWiseProfileId, getWiseEnvironmentConfig, getWiseAccessToken } from '../db';
+
+export const fetchProfileDetails = async () => {
+  const config = getWiseEnvironmentConfig();
+  const selectedProfileId = getSelectedWiseProfileId();
+  const oauthToken = getWiseAccessToken();
+  const headers = new Headers();
+  headers.set('Authorization', `Bearer ${oauthToken}`);
+  const response = await fetch(`${config.host}/v2/profiles/${selectedProfileId}`, { headers });
+  const result = await response.json();
+  return result;
+};

--- a/common/server/refreshWiseToken.ts
+++ b/common/server/refreshWiseToken.ts
@@ -2,8 +2,6 @@ import { getSelectedWiseProfileId, getWiseEnvironmentConfig, getWiseRefreshToken
 import store from '../db/mockDataStore';
 import { toUrlencoded } from '../utils/toUrlencoded';
 
-const MINUTE_IN_MS = 60 * 1000; 
-
 export const refreshWiseToken = async () => {
   const config = getWiseEnvironmentConfig();
   const refreshToken = getWiseRefreshToken();
@@ -24,8 +22,8 @@ export const refreshWiseToken = async () => {
     store.set(selectedProfileId, {
       accessToken: result.access_token,
       refreshToken: result.refresh_token,
-      // turns expires_in (seconds) into timestamp so we can use it later
-      accessTokenExpiresAt: Date.now() + (result.expires_in * MINUTE_IN_MS),
+      // Turns expires_in (seconds) into JS timestamp (milliseconds) so we can use it later
+      accessTokenExpiresAt: Date.now() + result.expires_in * 1000,
     });
   }
 };

--- a/common/server/refreshWiseToken.ts
+++ b/common/server/refreshWiseToken.ts
@@ -1,0 +1,31 @@
+import { getSelectedWiseProfileId, getWiseEnvironmentConfig, getWiseRefreshToken } from '../db';
+import store from '../db/mockDataStore';
+import { toUrlencoded } from '../utils/toUrlencoded';
+
+const MINUTE_IN_MS = 60 * 1000; 
+
+export const refreshWiseToken = async () => {
+  const config = getWiseEnvironmentConfig();
+  const refreshToken = getWiseRefreshToken();
+  const selectedProfileId = getSelectedWiseProfileId();
+  const headers = new Headers();
+  headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
+  headers.set(
+    'Authorization',
+    `Basic ${Buffer.from(`${config.clientId}:${config.clientSecret}`).toString('base64')}`,
+  );
+  const body = toUrlencoded({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  });
+  const response = await fetch(`${config.host}/oauth/token`, { method: 'POST', headers, body });
+  const result = await response.json();
+  if (result.access_token) {
+    store.set(selectedProfileId, {
+      accessToken: result.access_token,
+      refreshToken: result.refresh_token,
+      // turns expires_in (seconds) into timestamp so we can use it later
+      accessTokenExpiresAt: Date.now() + (result.expires_in * MINUTE_IN_MS),
+    });
+  }
+};

--- a/common/server/refreshWiseToken.ts
+++ b/common/server/refreshWiseToken.ts
@@ -1,5 +1,5 @@
 import { getSelectedWiseProfileId, getWiseEnvironmentConfig, getWiseRefreshToken } from '../db';
-import store from '../db/mockDataStore';
+import { store } from '../db';
 import { toUrlencoded } from '../utils/toUrlencoded';
 
 export const refreshWiseToken = async () => {

--- a/common/styles/globals.css
+++ b/common/styles/globals.css
@@ -1,0 +1,399 @@
+/* Based on: https://github.com/jenil/chota */
+/* Removed lots of things we don't need: col system, navigation etc. */
+:root {
+  --bg-color: #fff;
+  --bg-secondary-color: #f3f3f6;
+  --color-primary: #14854f;
+  --color-lightGrey: #d2d6dd;
+  --color-grey: #747681;
+  --color-darkGrey: #3f4144;
+  --color-error: #d43939;
+  --color-success: #28bd14;
+  --grid-maxWidth: 800px;
+  --grid-gutter: 2rem;
+  --font-size: 1.6rem;
+  --font-color: #333;
+  --font-family-sans: -apple-system, "BlinkMacSystemFont", "Avenir",
+    "Avenir Next", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
+    "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  --font-family-mono: monaco, "Consolas", "Lucida Console", monospace;
+}
+html {
+  box-sizing: border-box;
+  font-size: 62.5%;
+  line-height: 1.15;
+  text-size-adjust: 100%;
+}
+*,
+*::before,
+*::after {
+  -webkit-box-sizing: inherit;
+          box-sizing: inherit;
+}
+body {
+  background-color: var(--bg-color);
+  line-height: 1.6;
+  font-size: var(--font-size);
+  color: var(--font-color);
+  font-family: var(--font-family-sans);
+  margin: 0;
+  padding: 0;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 500;
+  margin: 0.35em 0 0.7em;
+}
+h1 {
+  font-size: 2em;
+}
+h2 {
+  font-size: 1.75em;
+}
+h3 {
+  font-size: 1.5em;
+}
+h4 {
+  font-size: 1.25em;
+}
+h5 {
+  font-size: 1em;
+}
+h6 {
+  font-size: 0.85em;
+}
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+a:hover:not(.button) {
+  opacity: 0.75;
+}
+button {
+  font-family: inherit;
+}
+p {
+  margin-top: 0;
+}
+blockquote {
+  background-color: var(--bg-secondary-color);
+  padding: 1.5rem 2rem;
+  border-left: 3px solid var(--color-lightGrey);
+}
+dl dt {
+  font-weight: bold;
+}
+hr {
+  border: none;
+  background-color: var(--color-lightGrey);
+  height: 1px;
+  margin: 1rem 0;
+}
+table {
+  width: 100%;
+  border: none;
+  border-collapse: collapse;
+  border-spacing: 0;
+  text-align: left;
+}
+table.striped tr:nth-of-type(2n) {
+  background-color: var(--bg-secondary-color);
+}
+td,
+th {
+  vertical-align: middle;
+  padding: 1.2rem 0.4rem;
+}
+thead {
+  border-bottom: 2px solid var(--color-lightGrey);
+}
+tfoot {
+  border-top: 2px solid var(--color-lightGrey);
+}
+code,
+kbd,
+pre,
+samp,
+tt {
+  font-family: var(--font-family-mono);
+}
+code,
+kbd {
+  font-size: 90%;
+  white-space: pre-wrap;
+  border-radius: 4px;
+  padding: 0.2em 0.4em;
+  background-color: var(--bg-secondary-color);
+  color: var(--color-error);
+}
+pre {
+  background-color: var(--bg-secondary-color);
+  font-size: 1em;
+  padding: 1rem;
+  overflow-x: auto;
+}
+pre code {
+  background: none;
+  padding: 0;
+}
+abbr[title] {
+  border-bottom: none;
+  text-decoration: underline;
+  -webkit-text-decoration: underline dotted;
+          text-decoration: underline dotted;
+}
+img {
+  max-width: 100%;
+}
+fieldset {
+  border: 1px solid var(--color-lightGrey);
+}
+iframe {
+  border: 0;
+}
+fieldset {
+  padding: 0.5rem 2rem;
+}
+legend {
+  text-transform: uppercase;
+  font-size: 0.8em;
+  letter-spacing: 0.1rem;
+}
+input:not([type="checkbox"], [type="radio"], [type="submit"], [type="color"], [type="button"], [type="reset"]),
+select,
+textarea,
+textarea[type="text"] {
+  font-family: inherit;
+  padding: 0.8rem 1rem;
+  border-radius: 4px;
+  border: 1px solid var(--color-lightGrey);
+  font-size: 1em;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
+  display: block;
+  width: 100%;
+  margin-bottom: 8px;
+}
+select {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  background: #f3f3f6 no-repeat 100%;
+  background-size: 1ex;
+  background-origin: content-box;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='60' height='40' fill='%23555'><polygon points='0,0 60,0 30,40'/></svg>");
+}
+.button,
+[type="button"],
+[type="reset"],
+[type="submit"],
+button {
+  padding: 1rem 2.5rem;
+  color: var(--color-darkGrey);
+  background: var(--color-lightGrey);
+  border-radius: 4px;
+  border: 1px solid transparent;
+  font-size: var(--font-size);
+  line-height: 1;
+  text-align: center;
+  -webkit-transition: opacity 0.2s ease;
+  transition: opacity 0.2s ease;
+  text-decoration: none;
+  -webkit-transform: scale(1);
+          transform: scale(1);
+  display: inline-block;
+  width: 100%;
+  cursor: pointer;
+  margin-bottom: 8px;
+}
+.button.primary,
+.button.secondary,
+.button.dark,
+.button.error,
+.button.success,
+[type="submit"] {
+  color: #fff;
+  z-index: 1; /* hightlight from other button's border when grouped */
+  background-color: #000;
+  background-color: var(--color-primary);
+}
+.button:hover,
+[type="button"]:hover,
+[type="reset"]:hover,
+[type="submit"]:hover,
+button:hover {
+  opacity: 0.8;
+}
+input:disabled,
+input:disabled:hover,
+button:disabled,
+button:disabled:hover {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+input:not([type="checkbox"], [type="radio"], [type="submit"], [type="color"], [type="button"], [type="reset"], :disabled):hover,
+select:hover,
+textarea:hover,
+textarea[type="text"]:hover {
+  border-color: var(--color-grey);
+}
+input:not([type="checkbox"], [type="radio"], [type="submit"], [type="color"], [type="button"], [type="reset"]):focus,
+select:focus,
+textarea:focus,
+textarea[type="text"]:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  -webkit-box-shadow: 0 0 1px var(--color-primary);
+          box-shadow: 0 0 1px var(--color-primary);
+}
+input.error:not([type="checkbox"], [type="radio"], [type="submit"], [type="color"], [type="button"], [type="reset"]),
+textarea.error {
+  border-color: var(--color-error);
+}
+input.success:not([type="checkbox"], [type="radio"], [type="submit"], [type="color"], [type="button"], [type="reset"]),
+textarea.success {
+  border-color: var(--color-success);
+}
+[type="checkbox"],
+[type="radio"] {
+  width: 2rem;
+  height: 1.6rem;
+}
+/* BUTTONS */
+.button + .button {
+  margin-left: 1rem;
+}
+.button.secondary {
+  background-color: var(--color-grey);
+}
+.button.dark {
+  background-color: var(--color-darkGrey);
+}
+.button.error {
+  background-color: var(--color-error);
+}
+.button.success {
+  background-color: var(--color-success);
+}
+.button.outline {
+  background-color: transparent;
+  border-color: var(--color-lightGrey);
+}
+.button.outline.primary {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+.button.outline.secondary {
+  border-color: var(--color-grey);
+  color: var(--color-grey);
+}
+.button.outline.dark {
+  border-color: var(--color-darkGrey);
+  color: var(--color-darkGrey);
+}
+.button.clear {
+  background-color: transparent;
+  border-color: transparent;
+  color: var(--color-primary);
+}
+.button.icon {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+}
+.button.icon > img {
+  margin-left: 2px;
+}
+.button.icon-only {
+  padding: 1rem;
+}
+.button:active:not(:disabled),
+[type="button"]:active:not(:disabled),
+[type="reset"]:active:not(:disabled),
+[type="submit"]:active:not(:disabled),
+button:active:not(:disabled) {
+  -webkit-transform: scale(0.98);
+          transform: scale(0.98);
+}
+::-webkit-input-placeholder {
+  color: #bdbfc4;
+}
+::-moz-placeholder {
+  color: #bdbfc4;
+}
+:-ms-input-placeholder {
+  color: #bdbfc4;
+}
+::-ms-input-placeholder {
+  color: #bdbfc4;
+}
+::placeholder {
+  color: #bdbfc4;
+}
+/* Colors */
+.bg-primary {
+  background-color: var(--color-primary) !important;
+}
+.bg-light {
+  background-color: var(--color-lightGrey) !important;
+}
+.bg-dark {
+  background-color: var(--color-darkGrey) !important;
+}
+.bg-grey {
+  background-color: var(--color-grey) !important;
+}
+.bg-error {
+  background-color: var(--color-error) !important;
+}
+.bg-success {
+  background-color: var(--color-success) !important;
+}
+.text-primary {
+  color: var(--color-primary) !important;
+}
+.text-light {
+  color: var(--color-lightGrey) !important;
+}
+.text-dark {
+  color: var(--color-darkGrey) !important;
+}
+.text-grey {
+  color: var(--color-grey) !important;
+}
+.text-error {
+  color: var(--color-error) !important;
+}
+.text-success {
+  color: var(--color-success) !important;
+}
+.text-white {
+  color: #fff !important;
+}
+/* Container */
+.container {
+  max-width: var(--grid-maxWidth);
+  margin: 3em auto;
+  width: 96%;
+  padding: 0 calc(var(--grid-gutter) / 2);
+}
+/* Spacing, utilities etc */
+.p-a-1 {
+  padding: 8px;
+}
+.m-t-1 {
+  margin-top: 8px;
+}
+.m-b-1 {
+  margin-bottom: 8px;
+}
+.border-1 {
+  border-radius: 4px;
+}

--- a/common/types/Config.ts
+++ b/common/types/Config.ts
@@ -1,0 +1,7 @@
+export type Config = {
+  host: string
+  clientId: string
+  clientSecret: string
+  redirectUri: string
+  oauthPageUrl: string
+};

--- a/common/types/Tokens.ts
+++ b/common/types/Tokens.ts
@@ -1,0 +1,5 @@
+export type Tokens = {
+  accessToken: string
+  refreshToken: string
+  accessTokenExpiresAt: string
+};

--- a/common/utils/getPostBodyAsURLSearchParams.ts
+++ b/common/utils/getPostBodyAsURLSearchParams.ts
@@ -1,0 +1,10 @@
+import { IncomingMessage } from 'http';
+
+// Makes accessing POST parameters easier
+export const getPostBodyAsURLSearchParams = async (req: IncomingMessage): Promise<URLSearchParams> => {
+  return new Promise((resolve) => {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => resolve(new URLSearchParams(body)));
+  });
+};

--- a/common/utils/toUrlencoded.ts
+++ b/common/utils/toUrlencoded.ts
@@ -1,0 +1,4 @@
+// Converts an object to urlencoded string. Example: { a:1, b:'2', c:true } -> "a=1&b=2&c=true"
+export const toUrlencoded = (input: Record<string, string>) => {
+  return new URLSearchParams(Object.entries(input)).toString();
+};

--- a/oauth-connect/.gitignore
+++ b/oauth-connect/.gitignore
@@ -1,0 +1,35 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+**/.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/oauth-connect/README.md
+++ b/oauth-connect/README.md
@@ -1,0 +1,38 @@
+This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+
+## Getting Started
+
+First, run the development server:
+
+```bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+
+[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+
+The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+
+This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+
+## Learn More
+
+To learn more about Next.js, take a look at the following resources:
+
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+
+You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+
+## Deploy on Vercel
+
+The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+
+Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.

--- a/oauth-connect/README.md
+++ b/oauth-connect/README.md
@@ -1,6 +1,6 @@
 # OAuth Connect Sample 
 
-This is an sample code of how to customer can connect their app to your app.
+This is an sample code of how to customer can connect their Wise account to your app.
 
 More info on our [API docs](https://docs.wise.com/api-docs/features/authentication-access).
 

--- a/oauth-connect/README.md
+++ b/oauth-connect/README.md
@@ -1,38 +1,22 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# OAuth Connect Sample 
 
-## Getting Started
+This is an sample code of how to customer can connect their app to your app.
 
-First, run the development server:
+More info on our [API docs](https://docs.wise.com/api-docs/features/authentication-access).
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-```
+## Key elements
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+We're using [Next.js](https://nextjs.org/), because it allows us to show server and client side code in single app.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+Start off by exploring `/pages/index.tsx`.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+## Running it locally
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+Prerequisite: make sure you have [Node.js](https://nodejs.org/en) installed.
+- `npm install` (installs all the packages)
+- `npm run dev` (starts the app at http://localhost:3000/)
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+## Recording
 
-## Learn More
+https://github.com/transferwise/wise-platform-samples/assets/39053304/58910b2b-c41a-441b-bafc-43ab7da9a8e7
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.

--- a/oauth-connect/README.md
+++ b/oauth-connect/README.md
@@ -6,7 +6,7 @@ More info on our [API docs](https://docs.wise.com/api-docs/features/authenticati
 
 ## Key elements
 
-We're using [Next.js](https://nextjs.org/), because it allows us to show server and client side code in single app.
+We're using [Next.js](https://nextjs.org/), because it allows us to show server and client side code in a single app.
 
 Start off by exploring `/pages/index.tsx`.
 

--- a/oauth-connect/next.config.js
+++ b/oauth-connect/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['common'],
+}
+
+module.exports = nextConfig

--- a/oauth-connect/package-lock.json
+++ b/oauth-connect/package-lock.json
@@ -1,0 +1,724 @@
+{
+  "name": "oauth-connect",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "oauth-connect",
+      "version": "0.1.0",
+      "dependencies": {
+        "@types/node": "20.6.2",
+        "@types/react": "18.2.21",
+        "@types/react-dom": "18.2.7",
+        "next": "13.4.19",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "typescript": "5.2.2"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
+      "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
+      "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
+      "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
+      "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
+      "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
+      "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
+      "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
+      "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
+      "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
+      "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.2.tgz",
+      "integrity": "sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw=="
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
+      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
+      "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001535",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001535.tgz",
+      "integrity": "sha512-48jLyUkiWFfhm/afF7cQPqPjaUmSraEhK4j+FCTJpgnGGEZHqyLe3hmWH7lIooZdSzXL0ReMvHz0vKDoTBsrwg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
+      "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
+      "dependencies": {
+        "@next/env": "13.4.19",
+        "@swc/helpers": "0.5.1",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001406",
+        "postcss": "8.4.14",
+        "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0",
+        "zod": "3.21.4"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=16.8.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "13.4.19",
+        "@next/swc-darwin-x64": "13.4.19",
+        "@next/swc-linux-arm64-gnu": "13.4.19",
+        "@next/swc-linux-arm64-musl": "13.4.19",
+        "@next/swc-linux-x64-gnu": "13.4.19",
+        "@next/swc-linux-x64-musl": "13.4.19",
+        "@next/swc-win32-arm64-msvc": "13.4.19",
+        "@next/swc-win32-ia32-msvc": "13.4.19",
+        "@next/swc-win32-x64-msvc": "13.4.19"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "node_modules/postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  },
+  "dependencies": {
+    "@next/env": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
+      "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
+      "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
+      "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
+      "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
+      "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
+      "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
+      "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
+      "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
+      "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
+      "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
+      "optional": true
+    },
+    "@swc/helpers": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@types/node": {
+      "version": "20.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.2.tgz",
+      "integrity": "sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw=="
+    },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "@types/react": {
+      "version": "18.2.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
+      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
+      "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001535",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001535.tgz",
+      "integrity": "sha512-48jLyUkiWFfhm/afF7cQPqPjaUmSraEhK4j+FCTJpgnGGEZHqyLe3hmWH7lIooZdSzXL0ReMvHz0vKDoTBsrwg=="
+    },
+    "client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+    },
+    "next": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
+      "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
+      "requires": {
+        "@next/env": "13.4.19",
+        "@next/swc-darwin-arm64": "13.4.19",
+        "@next/swc-darwin-x64": "13.4.19",
+        "@next/swc-linux-arm64-gnu": "13.4.19",
+        "@next/swc-linux-arm64-musl": "13.4.19",
+        "@next/swc-linux-x64-gnu": "13.4.19",
+        "@next/swc-linux-x64-musl": "13.4.19",
+        "@next/swc-win32-arm64-msvc": "13.4.19",
+        "@next/swc-win32-ia32-msvc": "13.4.19",
+        "@next/swc-win32-x64-msvc": "13.4.19",
+        "@swc/helpers": "0.5.1",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001406",
+        "postcss": "8.4.14",
+        "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0",
+        "zod": "3.21.4"
+      }
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "requires": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      }
+    },
+    "scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
+    "styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "requires": {
+        "client-only": "0.0.1"
+      }
+    },
+    "tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+    },
+    "watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "requires": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
+    }
+  }
+}

--- a/oauth-connect/package-lock.json
+++ b/oauth-connect/package-lock.json
@@ -8,24 +8,24 @@
       "name": "oauth-connect",
       "version": "0.1.0",
       "dependencies": {
-        "@types/node": "20.6.2",
-        "@types/react": "18.2.21",
-        "@types/react-dom": "18.2.7",
-        "next": "13.4.19",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "typescript": "5.2.2"
+        "@types/node": "^20.6.2",
+        "@types/react": "^18.2.21",
+        "@types/react-dom": "^18.2.7",
+        "next": "^13.4.19",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@next/env": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
-      "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.3.tgz",
+      "integrity": "sha512-X4te86vsbjsB7iO4usY9jLPtZ827Mbx+WcwNBGUOIuswuTAKQtzsuoxc/6KLxCMvogKG795MhrR1LDhYgDvasg=="
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
-      "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.3.tgz",
+      "integrity": "sha512-6hiYNJxJmyYvvKGrVThzo4nTcqvqUTA/JvKim7Auaj33NexDqSNwN5YrrQu+QhZJCIpv2tULSHt+lf+rUflLSw==",
       "cpu": [
         "arm64"
       ],
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
-      "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.3.tgz",
+      "integrity": "sha512-UpBKxu2ob9scbpJyEq/xPgpdrgBgN3aLYlxyGqlYX5/KnwpJpFuIHU2lx8upQQ7L+MEmz+fA1XSgesoK92ppwQ==",
       "cpu": [
         "x64"
       ],
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
-      "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.3.tgz",
+      "integrity": "sha512-5AzM7Yx1Ky+oLY6pHs7tjONTF22JirDPd5Jw/3/NazJ73uGB05NqhGhB4SbeCchg7SlVYVBeRMrMSZwJwq/xoA==",
       "cpu": [
         "arm64"
       ],
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
-      "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.3.tgz",
+      "integrity": "sha512-A/C1shbyUhj7wRtokmn73eBksjTM7fFQoY2v/0rTM5wehpkjQRLOXI8WJsag2uLhnZ4ii5OzR1rFPwoD9cvOgA==",
       "cpu": [
         "arm64"
       ],
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
-      "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.3.tgz",
+      "integrity": "sha512-FubPuw/Boz8tKkk+5eOuDHOpk36F80rbgxlx4+xty/U71e3wZZxVYHfZXmf0IRToBn1Crb8WvLM9OYj/Ur815g==",
       "cpu": [
         "x64"
       ],
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
-      "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.3.tgz",
+      "integrity": "sha512-DPw8nFuM1uEpbX47tM3wiXIR0Qa+atSzs9Q3peY1urkhofx44o7E1svnq+a5Q0r8lAcssLrwiM+OyJJgV/oj7g==",
       "cpu": [
         "x64"
       ],
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
-      "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.3.tgz",
+      "integrity": "sha512-zBPSP8cHL51Gub/YV8UUePW7AVGukp2D8JU93IHbVDu2qmhFAn9LWXiOOLKplZQKxnIPUkJTQAJDCWBWU4UWUA==",
       "cpu": [
         "arm64"
       ],
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
-      "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.3.tgz",
+      "integrity": "sha512-ONcL/lYyGUj4W37D4I2I450SZtSenmFAvapkJQNIJhrPMhzDU/AdfLkW98NvH1D2+7FXwe7yclf3+B7v28uzBQ==",
       "cpu": [
         "ia32"
       ],
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
-      "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.3.tgz",
+      "integrity": "sha512-2Vz2tYWaLqJvLcWbbTlJ5k9AN6JD7a5CN2pAeIzpbecK8ZF/yobA39cXtv6e+Z8c5UJuVOmaTldEAIxvsIux/Q==",
       "cpu": [
         "x64"
       ],
@@ -158,27 +158,27 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.2.tgz",
-      "integrity": "sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw=="
+      "version": "20.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
+      "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg=="
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "version": "15.7.7",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.7.tgz",
+      "integrity": "sha512-FbtmBWCcSa2J4zL781Zf1p5YUBXQomPEcep9QZCfRfQgTxz3pJWiDFLebohZ9fFntX5ibzOkSsrJ0TEew8cAog=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.21",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
-      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+      "version": "18.2.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.23.tgz",
+      "integrity": "sha512-qHLW6n1q2+7KyBEYnrZpcsAmU/iiCh9WGCKgXvMxx89+TYdJWRjZohVIo9XTcoLhfX3+/hP0Pbulu3bCZQ9PSA==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -186,17 +186,17 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
-      "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.8.tgz",
+      "integrity": "sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==",
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/scheduler": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.4.tgz",
+      "integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ=="
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001535",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001535.tgz",
-      "integrity": "sha512-48jLyUkiWFfhm/afF7cQPqPjaUmSraEhK4j+FCTJpgnGGEZHqyLe3hmWH7lIooZdSzXL0ReMvHz0vKDoTBsrwg==",
+      "version": "1.0.30001541",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+      "integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
       "funding": [
         {
           "type": "opencollective",
@@ -282,12 +282,12 @@
       }
     },
     "node_modules/next": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
-      "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.5.3.tgz",
+      "integrity": "sha512-4Nt4HRLYDW/yRpJ/QR2t1v63UOMS55A38dnWv3UDOWGezuY0ZyFO1ABNbD7mulVzs9qVhgy2+ppjdsANpKP1mg==",
       "dependencies": {
-        "@next/env": "13.4.19",
-        "@swc/helpers": "0.5.1",
+        "@next/env": "13.5.3",
+        "@swc/helpers": "0.5.2",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -299,18 +299,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=16.8.0"
+        "node": ">=16.14.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.19",
-        "@next/swc-darwin-x64": "13.4.19",
-        "@next/swc-linux-arm64-gnu": "13.4.19",
-        "@next/swc-linux-arm64-musl": "13.4.19",
-        "@next/swc-linux-x64-gnu": "13.4.19",
-        "@next/swc-linux-x64-musl": "13.4.19",
-        "@next/swc-win32-arm64-msvc": "13.4.19",
-        "@next/swc-win32-ia32-msvc": "13.4.19",
-        "@next/swc-win32-x64-msvc": "13.4.19"
+        "@next/swc-darwin-arm64": "13.5.3",
+        "@next/swc-darwin-x64": "13.5.3",
+        "@next/swc-linux-arm64-gnu": "13.5.3",
+        "@next/swc-linux-arm64-musl": "13.5.3",
+        "@next/swc-linux-x64-gnu": "13.5.3",
+        "@next/swc-linux-x64-musl": "13.5.3",
+        "@next/swc-win32-arm64-msvc": "13.5.3",
+        "@next/swc-win32-ia32-msvc": "13.5.3",
+        "@next/swc-win32-x64-msvc": "13.5.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -464,86 +464,86 @@
   },
   "dependencies": {
     "@next/env": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
-      "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.3.tgz",
+      "integrity": "sha512-X4te86vsbjsB7iO4usY9jLPtZ827Mbx+WcwNBGUOIuswuTAKQtzsuoxc/6KLxCMvogKG795MhrR1LDhYgDvasg=="
     },
     "@next/swc-darwin-arm64": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
-      "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.3.tgz",
+      "integrity": "sha512-6hiYNJxJmyYvvKGrVThzo4nTcqvqUTA/JvKim7Auaj33NexDqSNwN5YrrQu+QhZJCIpv2tULSHt+lf+rUflLSw==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
-      "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.3.tgz",
+      "integrity": "sha512-UpBKxu2ob9scbpJyEq/xPgpdrgBgN3aLYlxyGqlYX5/KnwpJpFuIHU2lx8upQQ7L+MEmz+fA1XSgesoK92ppwQ==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
-      "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.3.tgz",
+      "integrity": "sha512-5AzM7Yx1Ky+oLY6pHs7tjONTF22JirDPd5Jw/3/NazJ73uGB05NqhGhB4SbeCchg7SlVYVBeRMrMSZwJwq/xoA==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
-      "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.3.tgz",
+      "integrity": "sha512-A/C1shbyUhj7wRtokmn73eBksjTM7fFQoY2v/0rTM5wehpkjQRLOXI8WJsag2uLhnZ4ii5OzR1rFPwoD9cvOgA==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
-      "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.3.tgz",
+      "integrity": "sha512-FubPuw/Boz8tKkk+5eOuDHOpk36F80rbgxlx4+xty/U71e3wZZxVYHfZXmf0IRToBn1Crb8WvLM9OYj/Ur815g==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
-      "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.3.tgz",
+      "integrity": "sha512-DPw8nFuM1uEpbX47tM3wiXIR0Qa+atSzs9Q3peY1urkhofx44o7E1svnq+a5Q0r8lAcssLrwiM+OyJJgV/oj7g==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
-      "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.3.tgz",
+      "integrity": "sha512-zBPSP8cHL51Gub/YV8UUePW7AVGukp2D8JU93IHbVDu2qmhFAn9LWXiOOLKplZQKxnIPUkJTQAJDCWBWU4UWUA==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
-      "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.3.tgz",
+      "integrity": "sha512-ONcL/lYyGUj4W37D4I2I450SZtSenmFAvapkJQNIJhrPMhzDU/AdfLkW98NvH1D2+7FXwe7yclf3+B7v28uzBQ==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
-      "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.3.tgz",
+      "integrity": "sha512-2Vz2tYWaLqJvLcWbbTlJ5k9AN6JD7a5CN2pAeIzpbecK8ZF/yobA39cXtv6e+Z8c5UJuVOmaTldEAIxvsIux/Q==",
       "optional": true
     },
     "@swc/helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@types/node": {
-      "version": "20.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.2.tgz",
-      "integrity": "sha512-Y+/1vGBHV/cYk6OI1Na/LHzwnlNCAfU3ZNGrc1LdRe/LAIbdDPTTv/HU3M7yXN448aTVDq3eKRm2cg7iKLb8gw=="
+      "version": "20.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.1.tgz",
+      "integrity": "sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg=="
     },
     "@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "version": "15.7.7",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.7.tgz",
+      "integrity": "sha512-FbtmBWCcSa2J4zL781Zf1p5YUBXQomPEcep9QZCfRfQgTxz3pJWiDFLebohZ9fFntX5ibzOkSsrJ0TEew8cAog=="
     },
     "@types/react": {
-      "version": "18.2.21",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
-      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+      "version": "18.2.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.23.tgz",
+      "integrity": "sha512-qHLW6n1q2+7KyBEYnrZpcsAmU/iiCh9WGCKgXvMxx89+TYdJWRjZohVIo9XTcoLhfX3+/hP0Pbulu3bCZQ9PSA==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -551,17 +551,17 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.2.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
-      "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.8.tgz",
+      "integrity": "sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==",
       "requires": {
         "@types/react": "*"
       }
     },
     "@types/scheduler": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
+      "version": "0.16.4",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.4.tgz",
+      "integrity": "sha512-2L9ifAGl7wmXwP4v3pN4p2FLhD0O1qsJpvKmNin5VA8+UvNVb447UDaAEV6UdrkA+m/Xs58U1RFps44x6TFsVQ=="
     },
     "busboy": {
       "version": "1.6.0",
@@ -572,9 +572,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001535",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001535.tgz",
-      "integrity": "sha512-48jLyUkiWFfhm/afF7cQPqPjaUmSraEhK4j+FCTJpgnGGEZHqyLe3hmWH7lIooZdSzXL0ReMvHz0vKDoTBsrwg=="
+      "version": "1.0.30001541",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+      "integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw=="
     },
     "client-only": {
       "version": "0.0.1",
@@ -615,21 +615,21 @@
       "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
     },
     "next": {
-      "version": "13.4.19",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
-      "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.5.3.tgz",
+      "integrity": "sha512-4Nt4HRLYDW/yRpJ/QR2t1v63UOMS55A38dnWv3UDOWGezuY0ZyFO1ABNbD7mulVzs9qVhgy2+ppjdsANpKP1mg==",
       "requires": {
-        "@next/env": "13.4.19",
-        "@next/swc-darwin-arm64": "13.4.19",
-        "@next/swc-darwin-x64": "13.4.19",
-        "@next/swc-linux-arm64-gnu": "13.4.19",
-        "@next/swc-linux-arm64-musl": "13.4.19",
-        "@next/swc-linux-x64-gnu": "13.4.19",
-        "@next/swc-linux-x64-musl": "13.4.19",
-        "@next/swc-win32-arm64-msvc": "13.4.19",
-        "@next/swc-win32-ia32-msvc": "13.4.19",
-        "@next/swc-win32-x64-msvc": "13.4.19",
-        "@swc/helpers": "0.5.1",
+        "@next/env": "13.5.3",
+        "@next/swc-darwin-arm64": "13.5.3",
+        "@next/swc-darwin-x64": "13.5.3",
+        "@next/swc-linux-arm64-gnu": "13.5.3",
+        "@next/swc-linux-arm64-musl": "13.5.3",
+        "@next/swc-linux-x64-gnu": "13.5.3",
+        "@next/swc-linux-x64-musl": "13.5.3",
+        "@next/swc-win32-arm64-msvc": "13.5.3",
+        "@next/swc-win32-ia32-msvc": "13.5.3",
+        "@next/swc-win32-x64-msvc": "13.5.3",
+        "@swc/helpers": "0.5.2",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",

--- a/oauth-connect/package.json
+++ b/oauth-connect/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "oauth-connect",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@types/node": "20.6.2",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "next": "13.4.19",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "typescript": "5.2.2"
+  }
+}

--- a/oauth-connect/package.json
+++ b/oauth-connect/package.json
@@ -9,12 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@types/node": "20.6.2",
-    "@types/react": "18.2.21",
-    "@types/react-dom": "18.2.7",
-    "next": "13.4.19",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "typescript": "5.2.2"
+    "@types/node": "^20.6.2",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "next": "^13.4.19",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.2.2"
   }
 }

--- a/oauth-connect/pages/_app.tsx
+++ b/oauth-connect/pages/_app.tsx
@@ -1,0 +1,7 @@
+import type { AppProps } from 'next/app';
+
+import '../../common/styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+};

--- a/oauth-connect/pages/_app.tsx
+++ b/oauth-connect/pages/_app.tsx
@@ -3,5 +3,5 @@ import type { AppProps } from 'next/app';
 import '../../common/styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
-};
+  return <Component {...pageProps} />;
+}

--- a/oauth-connect/pages/_document.tsx
+++ b/oauth-connect/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/oauth-connect/pages/_document.tsx
+++ b/oauth-connect/pages/_document.tsx
@@ -1,4 +1,4 @@
-import { Html, Head, Main, NextScript } from 'next/document'
+import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
@@ -9,5 +9,5 @@ export default function Document() {
         <NextScript />
       </body>
     </Html>
-  )
+  );
 }

--- a/oauth-connect/pages/env-setup.tsx
+++ b/oauth-connect/pages/env-setup.tsx
@@ -1,5 +1,4 @@
-// This component/page is responsible for making sure that all the
-// required variables are stored in mock storage.
+// Special page for setting up environment vars. You wouldn't need it on your app!
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useState } from 'react';

--- a/oauth-connect/pages/env-setup.tsx
+++ b/oauth-connect/pages/env-setup.tsx
@@ -1,0 +1,114 @@
+// This component/page is responsible for making sure that all the
+// required variables are stored in mock storage.
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import { useState } from 'react';
+
+import { DEFAULT_REDIRECT_URI } from '../../common/const';
+import store from '../../common/db/mockDataStore';
+import { getPostBodyAsURLSearchParams } from '../../common/utils/getPostBodyAsURLSearchParams';
+
+// This function runs only on the server side.
+// If form gets submitted, we store the variables in our mock data store
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  if (req.method === 'POST') {
+    const body = await getPostBodyAsURLSearchParams(req);
+    store.set('config', {
+      host: body.get('host'),
+      clientId: body.get('clientId'),
+      clientSecret: body.get('clientSecret'),
+      redirectUri: body.get('redirectUri'),
+      oauthPageUrl: body.get('oauthPageUrl'),
+    });
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
+  return { props: {} };
+};
+
+export default function EnvSetupPage() {
+  const [redirectUri, setRedirectUri] = useState(DEFAULT_REDIRECT_URI);
+  return (
+    <>
+      <Head>
+        <title>Environment setup page</title>
+      </Head>
+      <main>
+        <div className="container">
+          {/* Submitting basically reloads the same page, but now getServerSideProps will receive POST parameters */}
+          <form action="/" method="POST">
+            <fieldset>
+              <legend>Environment variables</legend>
+              <p className="m-t-1">
+                In order to make calls to the Wise API, it's necessary to
+                configure certain environment variables.
+                <br />
+                Sample app stores those locally in <code>storage.json</code> file (root dir).<br />
+                <a href="https://docs.wise.com/api-docs/features/authentication-access">
+                  Read more about authentication & access
+                </a>
+                .
+              </p>
+              <label htmlFor="host">Host</label>
+              <input
+                type="text"
+                name="host"
+                id="host"
+                defaultValue="https://sandbox.transferwise.tech/gateway"
+                required
+              />
+              <label htmlFor="clientId">Client Id</label>
+              <input type="text" name="clientId" id="clientId" required />
+              <label htmlFor="clientSecret">Client Secret</label>
+              <input
+                type="text"
+                name="clientSecret"
+                id="clientSecret"
+                required
+              />
+              <label htmlFor="redirectUri">Redirect URI</label>
+              <input
+                type="text"
+                name="redirectUri"
+                id="redirectUri"
+                value={redirectUri}
+                onChange={(e) => setRedirectUri(e.target.value)}
+                required
+              />
+              {redirectUri !== DEFAULT_REDIRECT_URI && (
+                <p className="bg-light border-1 p-a-1">
+                  This sample app expects redirect URL to be{' '}
+                  <code>http://localhost:3000/wise-redirect</code>.<br /><br />
+                  You can still use the app though. Wise OAuth page redirects you back to:<br />
+                  <code>
+                    {redirectUri}?code=123&profileId=223
+                  </code>
+                  <br /> 
+                  You just have to copy the parameters and navigate to:<br />
+                  <code>
+                    http://localhost:3000/wise-redirect?code=123&profileId=223
+                  </code>
+                </p>
+              )}
+              <label htmlFor="oauthPageUrl">Wise OAuth page URL</label>
+              <input
+                type="text"
+                name="oauthPageUrl"
+                id="oauthPageUrl"
+                defaultValue="https://sandbox.transferwise.tech/oauth/authorize"
+                required
+              />
+              <button type="submit" className="m-t-1">
+                Save
+              </button>
+            </fieldset>
+          </form>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/oauth-connect/pages/env-setup.tsx
+++ b/oauth-connect/pages/env-setup.tsx
@@ -5,7 +5,7 @@ import Head from 'next/head';
 import { useState } from 'react';
 
 import { DEFAULT_REDIRECT_URI } from '../../common/const';
-import store from '../../common/db/mockDataStore';
+import { store } from '../../common/db';
 import { getPostBodyAsURLSearchParams } from '../../common/utils/getPostBodyAsURLSearchParams';
 
 // This function runs only on the server side.
@@ -47,7 +47,11 @@ export default function EnvSetupPage() {
                 In order to make calls to the Wise API, it's necessary to
                 configure certain environment variables.
                 <br />
-                Sample app stores those locally in <code>storage.json</code> file (root dir).<br />
+                Sample app stores those locally in <code>
+                  storage.json
+                </code>{' '}
+                file (root dir).
+                <br />
                 <a href="https://docs.wise.com/api-docs/features/authentication-access">
                   Read more about authentication & access
                 </a>
@@ -82,13 +86,15 @@ export default function EnvSetupPage() {
               {redirectUri !== DEFAULT_REDIRECT_URI && (
                 <p className="bg-light border-1 p-a-1">
                   This sample app expects redirect URL to be{' '}
-                  <code>http://localhost:3000/wise-redirect</code>.<br /><br />
-                  You can still use the app though. Wise OAuth page redirects you back to:<br />
-                  <code>
-                    {redirectUri}?code=123&profileId=223
-                  </code>
-                  <br /> 
-                  You just have to copy the parameters and navigate to:<br />
+                  <code>http://localhost:3000/wise-redirect</code>.<br />
+                  <br />
+                  You can still use the app though. Wise OAuth page redirects
+                  you back to:
+                  <br />
+                  <code>{redirectUri}?code=123&profileId=223</code>
+                  <br />
+                  You just have to copy the parameters and navigate to:
+                  <br />
                   <code>
                     http://localhost:3000/wise-redirect?code=123&profileId=223
                   </code>

--- a/oauth-connect/pages/index.tsx
+++ b/oauth-connect/pages/index.tsx
@@ -1,0 +1,108 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import { FC } from 'react';
+
+import { DEFAULT_REDIRECT_URI } from '../../common/const';
+import {
+  getWiseEnvironmentConfig,
+  getSelectedWiseProfileId,
+  isWiseTokenAboutToExpire,
+} from '../../common/db';
+import { fetchProfileDetails } from '../../common/server/fetchProfileDetails';
+import { refreshWiseToken } from '../../common/server/refreshWiseToken';
+
+// TODO: better comment.
+// This block runs on server side. So should run on your backend.
+export const getServerSideProps: GetServerSideProps<
+  OAuthConnectPageProps
+> = async () => {
+  // In order to make any calls to Wise API some environment variables must be set (clientId, clientSecret etc).
+  // In sample app we collect those in special page (/env-setup).
+  // Your application would store those details somewhere else, so no need to go in-depth on that setup.
+  const config = getWiseEnvironmentConfig();
+  if (!config) {
+    return {
+      redirect: {
+        destination: '/env-setup',
+        permanent: false,
+      },
+    };
+  }
+
+  // Check if accounts have been linked before
+  const isWiseAccountLinked = Boolean(getSelectedWiseProfileId());
+  if (isWiseAccountLinked) {
+    // no need to link again
+
+    // 3. token is expired, refresh token
+    if (isWiseTokenAboutToExpire()) {
+      await refreshWiseToken();
+    }
+
+    // We have a valid token
+    const profile = await fetchProfileDetails();
+    return { props: { name: profile.fullName } };
+  }
+
+  // We don't have a previous link on database, so we render the page
+  // where you can link your Wise account (current page, see below)
+  const wiseOauthPageUrl = `${config.oauthPageUrl}?client_id=${config.clientId}&redirect_uri=${config.redirectUri}`;
+  return { props: { wiseOauthPageUrl, redirectUri: config.redirectUri } };
+};
+
+type OAuthConnectPageProps = {
+  wiseOauthPageUrl?: string;
+  redirectUri?: string;
+  name?: string;
+};
+
+// TODO: comment, keys: frontend component of the page
+const OAuthConnectPage: FC<OAuthConnectPageProps> = ({
+  wiseOauthPageUrl,
+  redirectUri,
+  name,
+}) => {
+  return (
+    <>
+      <Head>
+        <title>OAuth Connect Sample</title>
+      </Head>
+      <main>
+        <div className="container">
+          <fieldset>
+            <legend>OAuth Connect Sample</legend>
+            {name ? (
+              <>
+                <h3>Hello {name}!</h3>
+                <p>Your account is successfully linked.</p>
+              </>
+            ) : (
+              <>
+                <p>
+                  You'll be redirected to Wise, where you can choose an account to authorize access.
+                </p>
+                {redirectUri !== DEFAULT_REDIRECT_URI && (
+                  <p className="bg-light border-1 p-a-1">
+                    The redirectUri in your config is different than this sample
+                    app uses.
+                    <br />
+                    When Wise OAuth page redirects you back please open the following link:
+                    <br />
+                    <code>
+                      http://localhost:3000/wise-redirect?code=...&profileId=...
+                    </code>
+                  </p>
+                )}
+                <a href={wiseOauthPageUrl} className="button primary">
+                  Connect your Wise account
+                </a>
+              </>
+            )}
+          </fieldset>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default OAuthConnectPage;

--- a/oauth-connect/pages/index.tsx
+++ b/oauth-connect/pages/index.tsx
@@ -11,98 +11,82 @@ import {
 import { fetchProfileDetails } from '../../common/server/fetchProfileDetails';
 import { refreshWiseToken } from '../../common/server/refreshWiseToken';
 
-// TODO: better comment.
-// This block runs on server side. So should run on your backend.
-export const getServerSideProps: GetServerSideProps<
-  OAuthConnectPageProps
-> = async () => {
-  // In order to make any calls to Wise API some environment variables must be set (clientId, clientSecret etc).
-  // In sample app we collect those in special page (/env-setup).
-  // Your application would store those details somewhere else, so no need to go in-depth on that setup.
-  const config = getWiseEnvironmentConfig();
-  if (!config) {
-    return {
-      redirect: {
-        destination: '/env-setup',
-        permanent: false,
-      },
-    };
-  }
-
-  // Check if accounts have been linked before
-  const isWiseAccountLinked = Boolean(getSelectedWiseProfileId());
-  if (isWiseAccountLinked) {
-    // no need to link again
-
-    // 3. token is expired, refresh token
-    if (isWiseTokenAboutToExpire()) {
-      await refreshWiseToken();
-    }
-
-    // We have a valid token
-    const profile = await fetchProfileDetails();
-    return { props: { name: profile.fullName } };
-  }
-
-  // We don't have a previous link on database, so we render the page
-  // where you can link your Wise account (current page, see below)
-  const wiseOauthPageUrl = `${config.oauthPageUrl}?client_id=${config.clientId}&redirect_uri=${config.redirectUri}`;
-  return { props: { wiseOauthPageUrl, redirectUri: config.redirectUri } };
-};
-
-type OAuthConnectPageProps = {
+type PageProps = {
   wiseOauthPageUrl?: string;
   redirectUri?: string;
   name?: string;
 };
 
-// TODO: comment, keys: frontend component of the page
-const OAuthConnectPage: FC<OAuthConnectPageProps> = ({
-  wiseOauthPageUrl,
-  redirectUri,
-  name,
-}) => {
-  return (
-    <>
-      <Head>
-        <title>OAuth Connect Sample</title>
-      </Head>
-      <main>
-        <div className="container">
-          <fieldset>
-            <legend>OAuth Connect Sample</legend>
-            {name ? (
-              <>
-                <h3>Hello {name}!</h3>
-                <p>Your account is successfully linked.</p>
-              </>
-            ) : (
-              <>
-                <p>
-                  You'll be redirected to Wise, where you can choose an account to authorize access.
-                </p>
-                {redirectUri !== DEFAULT_REDIRECT_URI && (
-                  <p className="bg-light border-1 p-a-1">
-                    The redirectUri in your config is different than this sample
-                    app uses.
-                    <br />
-                    When Wise OAuth page redirects you back please open the following link:
-                    <br />
-                    <code>
-                      http://localhost:3000/wise-redirect?code=...&profileId=...
-                    </code>
-                  </p>
-                )}
-                <a href={wiseOauthPageUrl} className="button primary">
-                  Connect your Wise account
-                </a>
-              </>
-            )}
-          </fieldset>
-        </div>
-      </main>
-    </>
-  );
+// This block runs on server side (on your backend) before anything is rendered.
+// We check if Wise account has already been linked. If not, we the UI will render "Connect" button.
+export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
+  const config = getWiseEnvironmentConfig(); // returns Wise API clientId, clientSecret, redirectUri etc.
+
+  // Special page for setting up environment vars. You wouldn't need it on your app!
+  if (!config) {
+    return { redirect: { destination: '/env-setup', permanent: false } };
+  }
+
+  // Check if accounts have been connected before (based on if selected profile exists)
+  const isWiseAccountConnected = Boolean(getSelectedWiseProfileId());
+  if (isWiseAccountConnected) {
+    // Generate new token if it is expired
+    if (isWiseTokenAboutToExpire()) {
+      await refreshWiseToken();
+    }
+
+    // We have a valid token, so we can call one of Wise API endpoints
+    const profile = await fetchProfileDetails();
+    return { props: { name: profile.fullName } };
+  }
+
+  // Accounts have not been connected. We render a "Connect your Wise account" button (see below)
+  const wiseOauthPageUrl = `${config.oauthPageUrl}?client_id=${config.clientId}&redirect_uri=${config.redirectUri}`;
+  return { props: { wiseOauthPageUrl, redirectUri: config.redirectUri } };
 };
+
+// Frontend component of the page. 
+// Renders a button to connect Wise Account or your name if already connected.
+const OAuthConnectPage: FC<PageProps> = (props) => (
+  <>
+    <Head>
+      <title>OAuth Connect Sample</title>
+    </Head>
+    <main>
+      <div className="container">
+        {props.name ? (
+          <>
+            <h1>Hello {props.name}!</h1>
+            <p>Your account is successfully connected.</p>
+          </>
+        ) : (
+          <>
+            <h1>OAuth Connect Sample</h1>
+            <p>
+              You'll be redirected to Wise, where you can choose an account
+              to authorize access.
+            </p>
+            {props.redirectUri !== DEFAULT_REDIRECT_URI && (
+              <p className="bg-light border-1 p-a-1">
+                The redirectUri in your config is different than this sample
+                app uses.
+                <br />
+                When Wise OAuth page redirects you back please open the
+                following link:
+                <br />
+                <code>
+                  http://localhost:3000/wise-redirect?code=...&profileId=...
+                </code>
+              </p>
+            )}
+            <a href={props.wiseOauthPageUrl} className="button primary">
+              Connect your Wise account
+            </a>
+          </>
+        )}
+      </div>
+    </main>
+  </>
+);
 
 export default OAuthConnectPage;

--- a/oauth-connect/pages/wise-redirect.tsx
+++ b/oauth-connect/pages/wise-redirect.tsx
@@ -1,0 +1,26 @@
+import { GetServerSideProps } from 'next';
+
+import { exchangeAuthCodeForToken } from '../../common/server/exchangeAuthCodeForToken';
+
+// After granting consent on Wise website you will be redirected back to this page.
+// The code must run on server side. There is no need for frontend views.
+// It reads the "code" and "profileId" parameters from the URL, then generates (and stores)
+// Wise API tokens and redirects to another page where you can start making API calls.
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  await exchangeAuthCodeForToken(
+    query.code as string,
+    query.profileId as string
+  );
+  // Redirect back to index page
+  return {
+    redirect: {
+      destination: '/',
+      permanent: false,
+    },
+  };
+};
+
+// You would always be redirected on the server side
+export default function WiseRedirectPage() {
+  return <p>Nothing to see here..</p>;
+}

--- a/oauth-connect/tsconfig.json
+++ b/oauth-connect/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Context

Generating sample app repo structure and adding a first sample app.
Idea is that it would be easy to add additional samples to the repo and those can share source in common.

Externals looking into samples should directly navigate into the sample they are interested in (OAuth connect, SCA etc..) and  the app there should be very lightweight and only contain relevant code for that specific use-case. 

Might be best to review using this view: https://github.com/transferwise/wise-platform-samples/tree/DEVEX-39_oauth-connect

## OAuth connect sample
https://github.com/transferwise/wise-platform-samples/assets/39053304/c7ba6e17-5f4e-4547-8784-648bd591b6e0

## Env setup screen
![Screenshot 2023-09-29 at 15 53 23](https://github.com/transferwise/wise-platform-samples/assets/39053304/7c289ae5-3269-4108-a65e-69300fc709d5)


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
